### PR TITLE
Interpreter Refactored Builtins for Use by Compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ There are now two new branches, <b>interpreter</b> and <b>compiler</b>, both bas
 
 Long term, the intent is to keep the master branch an interpreter based version of the Monkey language. Accordingly, changes may be merged from the interpreter branch into the master branch, and then into the compiler branch. However it is not anticipated that changes to the compiler branch will be merged into the master branch.
 
+#### December 21, 2021 Update
+
+In ["Writing A Compiler In Go"](https://compilerbook.com/) code from 
+["Writing An Interpreter In Go"](https://interpreterbook.com/) is refactored to move  built-in function logic from the `evaluator` package to the `object` package. This allows the interpreter and compiler to use the same codebase for built-in functions. This update was made first to the interpreter branch, used to update the master branch and then pulled into the compiler branch.

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -1,35 +1,16 @@
 package evaluator
 
 import (
-	"fmt"
 	"monkey/object"
 )
 
 var builtins = map[string]*object.Builtin{
-	"len":   {Fn: _len},
+	"len":   object.GetBuiltinByName("len"),
 	"first": {Fn: _first},
 	"last":  {Fn: _last},
 	"rest":  {Fn: _rest},
 	"push":  {Fn: _push},
-	"puts":  {Fn: _puts},
-}
-
-// lenght of a string or array
-func _len(args ...object.Object) object.Object {
-	if len(args) != 1 {
-		return newError("wrong number of arguments. got=%d, want=1",
-			len(args))
-	}
-
-	switch arg := args[0].(type) {
-	case *object.Array:
-		return &object.Integer{Value: int64(len(arg.Elements))}
-	case *object.String:
-		return &object.Integer{Value: int64(len(arg.Value))}
-	default:
-		return newError("argument to `len` not supported, got %s",
-			args[0].Type())
-	}
+	"puts":  object.GetBuiltinByName("puts"),
 }
 
 func _first(args ...object.Object) object.Object {
@@ -108,12 +89,4 @@ func _push(args ...object.Object) object.Object {
 	newElements[length] = args[1]
 
 	return &object.Array{Elements: newElements}
-}
-
-func _puts(args ...object.Object) object.Object {
-	for _, arg := range args {
-		fmt.Println(arg.Inspect())
-	}
-
-	return NULL
 }

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -6,87 +6,9 @@ import (
 
 var builtins = map[string]*object.Builtin{
 	"len":   object.GetBuiltinByName("len"),
-	"first": {Fn: _first},
-	"last":  {Fn: _last},
-	"rest":  {Fn: _rest},
-	"push":  {Fn: _push},
+	"first": object.GetBuiltinByName("first"),
+	"last":  object.GetBuiltinByName("last"),
+	"rest":  object.GetBuiltinByName("rest"),
+	"push":  object.GetBuiltinByName("push"),
 	"puts":  object.GetBuiltinByName("puts"),
-}
-
-func _first(args ...object.Object) object.Object {
-	if len(args) != 1 {
-		return newError("wrong number of arguments. got=%d, want=1",
-			len(args))
-	}
-	if args[0].Type() != object.ARRAY_OBJ {
-		return newError("argument to `first` must be ARRAY, got %s",
-			args[0].Type())
-	}
-
-	arr := args[0].(*object.Array)
-	if len(arr.Elements) > 0 {
-		return arr.Elements[0]
-	}
-
-	return NULL
-}
-
-func _last(args ...object.Object) object.Object {
-	if len(args) != 1 {
-		return newError("wrong number of arguments. got=%d, want=1",
-			len(args))
-	}
-	if args[0].Type() != object.ARRAY_OBJ {
-		return newError("argument to `last` must be ARRAY, got %s",
-			args[0].Type())
-	}
-
-	arr := args[0].(*object.Array)
-	length := len(arr.Elements)
-	if length > 0 {
-		return arr.Elements[length-1]
-	}
-
-	return NULL
-}
-
-func _rest(args ...object.Object) object.Object {
-	if len(args) != 1 {
-		return newError("wrong number of arguments. got=%d, want=1",
-			len(args))
-	}
-	if args[0].Type() != object.ARRAY_OBJ {
-		return newError("argument to `rest` must be ARRAY, got %s",
-			args[0].Type())
-	}
-
-	arr := args[0].(*object.Array)
-	length := len(arr.Elements)
-	if length > 0 {
-		newElements := make([]object.Object, length-1)
-		copy(newElements, arr.Elements[1:length])
-		return &object.Array{Elements: newElements}
-	}
-
-	return NULL
-}
-
-func _push(args ...object.Object) object.Object {
-	if len(args) != 2 {
-		return newError("wrong number of arguments. got=%d, want=2",
-			len(args))
-	}
-	if args[0].Type() != object.ARRAY_OBJ {
-		return newError("argument to `push` must be ARRAY, got %s",
-			args[0].Type())
-	}
-
-	arr := args[0].(*object.Array)
-	length := len(arr.Elements)
-
-	newElements := make([]object.Object, length+1)
-	copy(newElements, arr.Elements)
-	newElements[length] = args[1]
-
-	return &object.Array{Elements: newElements}
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -315,7 +315,10 @@ func applyFunction(fn object.Object, args []object.Object) object.Object {
 		return unwrapReturnValue(evaluated)
 
 	case *object.Builtin:
-		return fn.Fn(args...)
+		if result := fn.Fn(args...); result != nil {
+			return result
+		}
+		return NULL
 
 	default:
 		return newError("not a function: %s", fn.Type())

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -17,6 +17,10 @@ var Builtins = []struct {
 }{
 	{"len", &Builtin{Fn: _len}},
 	{"puts", &Builtin{Fn: _puts}},
+	{"first", &Builtin{Fn: _first}},
+	{"last", &Builtin{Fn: _last}},
+	{"rest", &Builtin{Fn: _rest}},
+	{"push", &Builtin{Fn: _push}},
 }
 
 func newError(format string, a ...interface{}) *Error {
@@ -46,4 +50,82 @@ func _puts(args ...Object) Object {
 	}
 
 	return nil
+}
+
+func _first(args ...Object) Object {
+	if len(args) != 1 {
+		return newError("wrong number of arguments. got=%d, want=1",
+			len(args))
+	}
+	if args[0].Type() != ARRAY_OBJ {
+		return newError("argument to `first` must be ARRAY, got %s",
+			args[0].Type())
+	}
+
+	arr := args[0].(*Array)
+	if len(arr.Elements) > 0 {
+		return arr.Elements[0]
+	}
+
+	return nil
+}
+
+func _last(args ...Object) Object {
+	if len(args) != 1 {
+		return newError("wrong number of arguments. got=%d, want=1",
+			len(args))
+	}
+	if args[0].Type() != ARRAY_OBJ {
+		return newError("argument to `last` must be ARRAY, got %s",
+			args[0].Type())
+	}
+
+	arr := args[0].(*Array)
+	length := len(arr.Elements)
+	if length > 0 {
+		return arr.Elements[length-1]
+	}
+
+	return nil
+}
+
+func _rest(args ...Object) Object {
+	if len(args) != 1 {
+		return newError("wrong number of arguments. got=%d, want=1",
+			len(args))
+	}
+	if args[0].Type() != ARRAY_OBJ {
+		return newError("argument to `rest` must be ARRAY, got %s",
+			args[0].Type())
+	}
+
+	arr := args[0].(*Array)
+	length := len(arr.Elements)
+	if length > 0 {
+		newElements := make([]Object, length-1)
+		copy(newElements, arr.Elements[1:length])
+		return &Array{Elements: newElements}
+	}
+
+	return nil
+}
+
+func _push(args ...Object) Object {
+	if len(args) != 2 {
+		return newError("wrong number of arguments. got=%d, want=2",
+			len(args))
+	}
+	if args[0].Type() != ARRAY_OBJ {
+		return newError("argument to `push` must be ARRAY, got %s",
+			args[0].Type())
+	}
+
+	arr := args[0].(*Array)
+	length := len(arr.Elements)
+
+	newElements := make([]Object, length+1)
+	copy(newElements, arr.Elements)
+	newElements[length] = args[1]
+
+	return &Array{Elements: newElements}
 }

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -1,0 +1,49 @@
+package object
+
+import "fmt"
+
+func GetBuiltinByName(name string) *Builtin {
+	for _, def := range Builtins {
+		if def.Name == name {
+			return def.Builtin
+		}
+	}
+	return nil
+}
+
+var Builtins = []struct {
+	Name    string
+	Builtin *Builtin
+}{
+	{"len", &Builtin{Fn: _len}},
+	{"puts", &Builtin{Fn: _puts}},
+}
+
+func newError(format string, a ...interface{}) *Error {
+	return &Error{Message: fmt.Sprintf(format, a...)}
+}
+
+func _len(args ...Object) Object {
+	if len(args) != 1 {
+		return newError("wrong number of arguments. got=%d, want=1",
+			len(args))
+	}
+
+	switch arg := args[0].(type) {
+	case *Array:
+		return &Integer{Value: int64(len(arg.Elements))}
+	case *String:
+		return &Integer{Value: int64(len(arg.Value))}
+	default:
+		return newError("argument to `len` not supported, got %s",
+			args[0].Type())
+	}
+}
+
+func _puts(args ...Object) Object {
+	for _, arg := range args {
+		fmt.Println(arg.Inspect())
+	}
+
+	return nil
+}


### PR DESCRIPTION
Built in functions moved from `evaluator` to `object` package so that interpreter and compiler can use the same codebase for built in functions.